### PR TITLE
injecting state using query string

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,6 +6,7 @@ nuget FSharp.Core >= 3.0
 nuget Fable.Core >= 3.0
 nuget Fable.Node
 nuget Fable.Browser.Dom
+nuget Fable.Browser.Url
 nuget Fable.Browser.Css
 nuget Fable.Fetch
 nuget Fable.React

--- a/src/index.fs
+++ b/src/index.fs
@@ -17,18 +17,6 @@ open JupyterlabServices.__kernel_kernel.Kernel
 let mutable requires: obj array =
     [| JupyterlabApputils.ICommandPalette; JupyterlabNotebook.Tokens.Types.INotebookTracker; JupyterlabApplication.ILayoutRestorer |]
 
-// /// id to self explanation map
-// let selfExplanationState = System.Collections.Generic.Dictionary<string,string>()
-
-// /// Log self explanation and save its state
-// let logSelfExplanation( text : string) ( id : string ) =
-//   Logging.LogToServer( Logging.JupyterLogEntry082720.Create "self-explanation" ( text |> Some ) ) 
-//   selfExplanationState.Add( id, text)
-
-// /// Simplest way to connect javascript injected into code cell output to F#: make a global function in node
-// let [<Global>] ``global`` : obj = jsNative
-// ``global``?logSelfExplanation <- logSelfExplanation
-
 //https://stackoverflow.com/questions/47640263/how-to-extend-a-js-class-in-fable
 [<Import("Widget", from = "@phosphor/widgets")>]
 [<AbstractClass>]
@@ -132,48 +120,6 @@ type BlocklyWidget(notebooks: JupyterlabNotebook.Tokens.INotebookTracker) as thi
         
         member this.onActiveCellChanged =
           PhosphorSignaling.Slot<JupyterlabNotebook.Tokens.INotebookTracker, JupyterlabNotebook.Tokens.Cell>(fun sender args ->  
-
-            // //SELF EXPLANATION: probe all cells b/c listening for kernel messages requires waiting to attach (we could poll instead...)
-            // // check ALL code cell outputs every time a cell changes
-            // let cells = this.Notebooks.currentWidget.Value.content.widgets
-            // for i = 0 to cells.length - 1 do
-            //   let cell = cells.[i]
-            //   if cell.model.``type`` = JupyterlabCoreutils.Nbformat.Nbformat.CellType.Code then
-            //     console.log ("I am a code cell")
-            //     let codeCell = cell :?> JupyterlabCells.Widget.CodeCell
-
-            //     //check if our self-explanation response box is already present; don't create duplicates!
-            //     let hasResposeBox =
-            //       [| 0.0 .. codeCell.outputArea.model.length - 1.0 |] 
-            //       |> Array.exists( fun i ->
-            //         let model = codeCell.outputArea.model.get(i) 
-            //         let html = model.data.["text/html"] |> unbox<string>
-            //         html <> null && html.Contains("self-explanation") //below we enforce that <textarea> has an id containing the string "self-explanation"
-            //       )
-                  
-            //     if not <| hasResposeBox then
-            //       //conveniently we have a unique persistent id
-            //       let modelId = codeCell.model.id
-            //       //retrieve the stored self-explanation if it exists
-            //       let selfExplanation = 
-            //         match selfExplanationState.TryGetValue(modelId) with
-            //           | true,se -> se //we have a stored self explanation
-            //           | false,_ -> "" //nothing stored
-
-            //       //if self explanation exists, display it in black; else display an empty textarea with red font
-            //       let displayData = //
-            //         createObj 
-            //           [
-            //             "output_type" ==> "display_data"
-            //             //inject the modelId into the textarea id; insert the stored self explanation if it exists; creating a logging handler with this information
-            //             "data" ==> createObj [ "text/html" ==> """<div style='display:inline-block;vertical-align: top;'><textarea id='self-explanation""" + modelId +  """' cols='60' rows='2'""" + (if selfExplanation = "" then " style='color:Tomato;'" else "") + ">" + selfExplanation  + """</textarea></div><div style='display:inline-block;vertical-align: top;'><button onclick="document.getElementById('self-explanation""" + modelId + """').style.color = 'black';logSelfExplanation(document.getElementById('self-explanation""" + modelId + """').value,'""" + modelId + """')">Enter</button></div>""" ]
-            //           ] :?> JupyterlabCoreutils.Nbformat.Nbformat.IOutput
-              
-            //       codeCell.outputArea.model.add( displayData ) |> ignore
-            //       // console.log("I added a self explanation a code cell's outputarea")
-            
-            // //end self-explanation
-            // //*****************************************
 
             //log the active cell change
             if args <> null then
@@ -303,7 +249,7 @@ type BlocklyWidget(notebooks: JupyterlabNotebook.Tokens.INotebookTracker) as thi
               console.log ("no cell active, flushed:\n" + code + "\n")
 
     end
-
+           
 /// Return a MainAreaWidget wrapping a BlocklyWidget
 let createMainAreaWidget( bw:BlocklyWidget)= 
   let w =
@@ -379,7 +325,17 @@ let extension =
                             palette?addItem (createObj
                                                  [ "command" ==> command
                                                    "category" ==> "Blockly" ])
-                                                   
+                            
+                            //Check query string for any injected state; if query string has bl=1, trigger the open command once the application is ready
+                            let searchParams = Browser.Url.URLSearchParams.Create(  Browser.Dom.window.location.search )
+                            match searchParams.get("bl") with
+                            | Some(state) when state = "1" ->
+                              console.log ("Blockly extension triggering open command based on query string input")
+                              app.restored.``then``(fun _ -> 
+                                app.commands.execute(command) |> ignore
+                                widget.title.closable <- false //do not allow blockly to be closed
+                                ) |> ignore  
+                            | _ -> ()
 
                           ) //Func
         ]

--- a/src/paket.references
+++ b/src/paket.references
@@ -2,6 +2,7 @@ FSharp.Core
 Fable.Core
 Fable.Node
 Fable.Browser.Dom
+Fable.Browser.Url
 Fable.Browser.Css
 Fable.Fetch
 Fable.React


### PR DESCRIPTION
`?bl=1` causes Blockly to auto-open and disables closing the extension by using the "x" on the tab