### PR TITLE
query string id injection

### DIFF
--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -31,14 +31,22 @@ type LogEntry =
         json: string
     }
 
-//No logging by default; only turn on if within olney.ai domain;
+/// No logging by default; only turn on if within olney.ai domain;
 let mutable shouldLog = false
+
+/// Where we are sending the data
 let LogServerEndpoint = "https://logging.olney.ai"
+ 
+let mutable idOption : string option = None
+
 /// Log to server. Basically this is Express wrapping a database, but repo is not public as of 8/25/20
 let LogToServer( logObject: obj ) = 
     if shouldLog then
         promise {
-            let username = Browser.Dom.window.location.href
+            let username = 
+                match idOption with
+                | Some(id) -> id
+                | None -> Browser.Dom.window.location.href
             do! Fetch.post( LogServerEndpoint + "/datawhys/log" , { username=username; json=toJson(logObject) } ) //caseStrategy = SnakeCase
         } |> ignore
 

--- a/src/index.fs
+++ b/src/index.fs
@@ -326,7 +326,7 @@ let extension =
                                                  [ "command" ==> command
                                                    "category" ==> "Blockly" ])
                             
-                            //Check query string for any injected state; if query string has bl=1, trigger the open command once the application is ready
+                            //If query string has bl=1, trigger the open command once the application is ready
                             let searchParams = Browser.Url.URLSearchParams.Create(  Browser.Dom.window.location.search )
                             match searchParams.get("bl") with
                             | Some(state) when state = "1" ->
@@ -335,6 +335,11 @@ let extension =
                                 app.commands.execute(command) |> ignore
                                 widget.title.closable <- false //do not allow blockly to be closed
                                 ) |> ignore  
+                            | _ -> ()
+
+                            //If query string has id=xxx, store this identifier as a participant id
+                            match searchParams.get("id") with
+                            | Some(id) -> Logging.idOption <- Some(id)
                             | _ -> ()
 
                           ) //Func


### PR DESCRIPTION
Example `id=xxx`