### PR TITLE
Improved logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 A [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) extension implementing a Blockly palette with [Fable](https://fable.io/) tooling.
 
-Blockly/JupyterLab events can be logged to a database using the Fetch API, but the current endpoint is hard-coded and deactivated by default.
+The following query string parameters enable functionality:
 
+- `bl=1` forces the extension to display on load (it is already active)
+- `log=xxx` specifies a url for a logging endpoint (e.g. https://yourdomain.com/log)
+- `id=xxx` adds an identifier for logging
 
 **NOTE: This plugin requires jupyterlab <= 1.2.6, so if you have a higher version (e.g. 2.X) you will need to execute `conda install jupyterlab=1.2.6` or similar for `pip`**
 


### PR DESCRIPTION
- Passing logging endpoint as query string parameter
- Blockly logging now logs whole objects