### PR TITLE
Syncv3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aolney/fable-jupyterlab-blockly-extension",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An JupyterLab extension for Blockly with Fable tooling",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
V3 of notebook sync; uses dirty flag to float blocks across cells unless the blocks have been written. Dropping a block on the workspace or loading blocks by deserializing from a cell both trigger the dirty flag.